### PR TITLE
Add support for "login paths" in both MySQL and MariaDB

### DIFF
--- a/automysqlbackup
+++ b/automysqlbackup
@@ -84,7 +84,8 @@ load_default_config() {
   CONFIG_mysql_dump_dbstatus='yes'
   CONFIG_mysql_dump_differential='no'
   CONFIG_mysql_dump_login_path='automysqldump'
-  CONFIG_mysql_dump_login_path_file=''
+  CONFIG_mysql_dump_login_path_file='automysqldump'
+  CONFIG_mysql_dump_config_extra_file=''
   CONFIG_mysql_dump_encrypted_login='no'
   CONFIG_backup_local_files=()
   CONFIG_db_names=()
@@ -113,11 +114,17 @@ mysql_commands() {
   VERSION=`mysql -V | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"`
   NODOT_VER=`echo $VERSION | sed $OS_sed_option 's/\.//g'`
   if [ "${CONFIG_mysql_dump_encrypted_login}" = "yes" ]; then
-    export MYSQLDUMP="mysqldump --login-path=$CONFIG_mysql_dump_login_path"
-    export MYSQLSHOW="mysqlshow --login-path=$CONFIG_mysql_dump_login_path"
-    export MYSQL="mysql --login-path=$CONFIG_mysql_dump_login_path"
-    if [ -n "${CONFIG_mysql_dump_login_path_file}" ]; then
-      export MYSQL_TEST_LOGIN_FILE=$CONFIG_mysql_dump_login_path_file
+    if [ "${CONFIG_mysql_dump_config_extra_file}" != "" ]; then
+      export MYSQLDUMP="mysqldump --defaults-extra-file=$CONFIG_mysql_dump_config_extra_file"
+      export MYSQLSHOW="mysqlshow --defaults-extra-file=$CONFIG_mysql_dump_config_extra_file"
+      export MYSQL="mysql --defaults-extra-file=$CONFIG_mysql_dump_config_extra_file"
+    else
+      export MYSQLDUMP="mysqldump --login-path=$CONFIG_mysql_dump_login_path"
+      export MYSQLSHOW="mysqlshow --login-path=$CONFIG_mysql_dump_login_path"
+      export MYSQL="mysql --login-path=$CONFIG_mysql_dump_login_path"
+      if [ -n "${CONFIG_mysql_dump_login_path_file}" ]; then
+        export MYSQL_TEST_LOGIN_FILE=$CONFIG_mysql_dump_login_path_file
+      fi
     fi
   else
     export MYSQLDUMP="mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";

--- a/automysqlbackup
+++ b/automysqlbackup
@@ -65,7 +65,7 @@ load_default_config() {
   CONFIG_rotation_weekly=35
   CONFIG_rotation_monthly=150
   CONFIG_mysql_dump_port=3306
-  CONFIG_mysql_dump_usessl='yes'
+  CONFIG_mysql_dump_usessl='no'
   CONFIG_mysql_dump_username='root'
   CONFIG_mysql_dump_password=''
   CONFIG_mysql_dump_host='localhost'
@@ -81,9 +81,11 @@ load_default_config() {
   CONFIG_mysql_dump_single_transaction='no'
   CONFIG_mysql_dump_master_data=
   CONFIG_mysql_dump_full_schema='yes'
-  CONFIG_mysql_dump_flush_logs='no'
   CONFIG_mysql_dump_dbstatus='yes'
   CONFIG_mysql_dump_differential='no'
+  CONFIG_mysql_dump_login_path='automysqldump'
+  CONFIG_mysql_dump_login_path_file=''
+  CONFIG_mysql_dump_encrypted_login='no'
   CONFIG_backup_local_files=()
   CONFIG_db_names=()
   CONFIG_db_month_names=()
@@ -96,6 +98,32 @@ load_default_config() {
   CONFIG_mail_address='root'
   CONFIG_encrypt='no'
   CONFIG_encrypt_password='password0123'
+}
+
+# OS dependent options (showstoppers on MacOS)
+  if [[ $OSTYPE == darwin* ]]; then
+    OS_sed_option='-E'
+    OS_du_extra_option=''
+  else
+    OS_sed_option='-r'
+    OS_du_extra_option='--si'
+  fi
+
+mysql_commands() {
+  VERSION=`mysql -V | grep -oE "[0-9]+\.[0-9]+\.[0-9]+"`
+  NODOT_VER=`echo $VERSION | sed $OS_sed_option 's/\.//g'`
+  if [ "${CONFIG_mysql_dump_encrypted_login}" = "yes" ]; then
+    export MYSQLDUMP="mysqldump --login-path=$CONFIG_mysql_dump_login_path"
+    export MYSQLSHOW="mysqlshow --login-path=$CONFIG_mysql_dump_login_path"
+    export MYSQL="mysql --login-path=$CONFIG_mysql_dump_login_path"
+    if [ -n "${CONFIG_mysql_dump_login_path_file}" ]; then
+      export MYSQL_TEST_LOGIN_FILE=$CONFIG_mysql_dump_login_path_file
+    fi
+  else
+    export MYSQLDUMP="mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
+    export MYSQLSHOW="mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
+    export MYSQL="mysql --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host}";
+  fi
 }
 
 # @return:	true, if variable is set; else false
@@ -438,7 +466,7 @@ backup_local_files () {
 # @deps:	load_default_config
 parse_configuration () {
     # OPT string for use with mysqldump ( see man mysqldump )
-    opt=( '--quote-names' '--opt' )
+    opt=( '--quote-names' '--opt' '--events' )
 
     # OPT string for use with mysql (see man mysql )
     mysql_opt=()
@@ -449,21 +477,26 @@ parse_configuration () {
 	# OPT string for use with mysqlstatus
 	opt_dbstatus=( '--status' )
 
-    [[ "${CONFIG_mysql_dump_usessl}" = "yes" ]] 		&& {
-	  opt=( "${opt[@]}" '--ssl' )
-	  mysql_opt=( "${mysql_opt[@]}" '--ssl' )
-	  opt_fullschema=( "${opt_fullschema[@]}" '--ssl' )
-	  opt_dbstatus=( "${opt_dbstatus[@]}" '--ssl' )
-    }
+	if [ "$NODOT_VER" -ge 56 ]; then
+		[[ "${CONFIG_mysql_dump_usessl}" = "yes" ]] 		&& {
+		  opt=( "${opt[@]}" '--ssl-mode=REQUIRED' )
+		  mysql_opt=( "${mysql_opt[@]}" '--ssl-mode=REQUIRED' )
+		  opt_fullschema=( "${opt_fullschema[@]}" '--ssl-mode=REQUIRED' )
+		  opt_dbstatus=( "${opt_dbstatus[@]}" '--ssl-mode=REQUIRED' )
+		}
+	else
+		[[ "${CONFIG_mysql_dump_usessl}" = "yes" ]] 		&& {
+		  opt=( "${opt[@]}" '--ssl' )
+		  mysql_opt=( "${mysql_opt[@]}" '--ssl' )
+		  opt_fullschema=( "${opt_fullschema[@]}" '--ssl' )
+		  opt_dbstatus=( "${opt_dbstatus[@]}" '--ssl' )
+		}
+	fi
     [[ "${CONFIG_mysql_dump_master_data}" ]] && (( ${CONFIG_mysql_dump_master_data} == 1 || ${CONFIG_mysql_dump_master_data} == 2 )) && { opt=( "${opt[@]}" "--master-data=${CONFIG_mysql_dump_master_data}" );}
     [[ "${CONFIG_mysql_dump_single_transaction}" = "yes" ]]	&& {
 	  opt=( "${opt[@]}" '--single-transaction' )
 	  opt_fullschema=( "${opt_fullschema[@]}" '--single-transaction' )
     }
-    [[ "${CONFIG_mysql_dump_flush_logs}" = "yes" ]]	&& {
-        opt=( "${opt[@]}" '--flush-logs' )
-    }
-
     [[ "${CONFIG_mysql_dump_commcomp}" = "yes" ]]		&& {
 	  opt=( "${opt[@]}" '--compress' )
 	  opt_fullschema=( "${opt_fullschema[@]}" '--compress' )
@@ -519,7 +552,7 @@ parse_configuration () {
 	  db=${i%.*}
 	  table=${i#"$db".}
 	  r='\*'; [[ "$i" =~ $r ]] || { tmp[z++]="$i"; continue; }
-	  while read -r; do tmp[z++]="${db}.${REPLY}"; done < <(mysql --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${mysql_opt[@]}" --batch --skip-column-names -e "select table_name from information_schema.tables where table_schema='${db}' and table_name like '${table//\*/%}';")
+	  while read -r; do tmp[z++]="${db}.${REPLY}"; done < <($MYSQL "${mysql_opt[@]}" --batch --skip-column-names -e "select table_name from information_schema.tables where table_schema='${db}' and table_name like '${table//\*/%}';")
 	done
 	for l in "${tmp[@]}"; do echo "exclude $l";done
 	CONFIG_table_exclude=("${tmp[@]}")
@@ -540,28 +573,28 @@ dbstatus() {
   if (( $CONFIG_dryrun )); then
     case "${CONFIG_mysql_dump_compression}" in
 	'gzip')
-	  echo "dry-running: mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_dbstatus[@]} | gzip_compression > ${1}${suffix}";
+	  echo "dry-running: $MYSQLSHOW ${opt_dbstatus[@]} | gzip_compression > ${1}${suffix}";
 	  ;;
 	'bzip2')
-	  echo "dry-running: mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_dbstatus[@]} | bzip2_compression > ${1}${suffix}";
+	  echo "dry-running: $MYSQLSHOW ${opt_dbstatus[@]} | bzip2_compression > ${1}${suffix}";
 	  ;;
 	*)
-	  echo "dry-running: mysqlshow --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_dbstatus[@]} > ${1}${suffix}";
+	  echo "dry-running: $MYSQLSHOW ${opt_dbstatus[@]} > ${1}${suffix}";
 	  ;;
     esac
     return 0;
   else
     case "${CONFIG_mysql_dump_compression}" in
 	'gzip')
-	  mysqlshow --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_dbstatus[@]}" | gzip_compression > "${1}${suffix}";
+	  $MYSQLSHOW "${opt_dbstatus[@]}" | gzip_compression > "${1}${suffix}";
 	  return $?
 	  ;;
 	'bzip2')
-	  mysqlshow --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_dbstatus[@]}" | bzip2_compression > "${1}${suffix}";
+	  $MYSQLSHOW "${opt_dbstatus[@]}" | bzip2_compression > "${1}${suffix}";
 	  return $?
 	  ;;
 	*)
-	  mysqlshow --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_dbstatus[@]}" > "${1}${suffix}";
+	  $MYSQLSHOW "${opt_dbstatus[@]}" > "${1}${suffix}";
 	  return $?
 	  ;;
     esac
@@ -576,28 +609,28 @@ fullschema () {
   if (( $CONFIG_dryrun )); then
     case "${CONFIG_mysql_dump_compression}" in
 	'gzip')
-	  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_fullschema[@]} | gzip_compression > ${1}${suffix}";
+	  echo "dry-running: $MYSQLDUMP ${opt_fullschema[@]} | gzip_compression > ${1}${suffix}";
 	  ;;
 	'bzip2')
-	  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_fullschema[@]} | bzip2_compression > ${1}${suffix}";
+	  echo "dry-running: $MYSQLDUMP ${opt_fullschema[@]} | bzip2_compression > ${1}${suffix}";
 	  ;;
 	*)
-	  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt_fullschema[@]} > ${1}${suffix}";
+	  echo "dry-running: $MYSQLDUMP ${opt_fullschema[@]} > ${1}${suffix}";
 	  ;;
     esac
     return 0;
   else
     case "${CONFIG_mysql_dump_compression}" in
 	'gzip')
-	  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_fullschema[@]}" | gzip_compression > "${1}${suffix}";
+	  $MYSQLDUMP "${opt_fullschema[@]}" | gzip_compression > "${1}${suffix}";
 	  return $?
 	  ;;
 	'bzip2')
-	  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_fullschema[@]}" | bzip2_compression > "${1}${suffix}";
+	  $MYSQLDUMP "${opt_fullschema[@]}" | bzip2_compression > "${1}${suffix}";
 	  return $?
 	  ;;
 	*)
-	  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt_fullschema[@]}" > "${1}${suffix}";
+	  $MYSQLDUMP "${opt_fullschema[@]}" > "${1}${suffix}";
 	  return $?
 	  ;;
     esac
@@ -715,13 +748,13 @@ process_dbs() {
 		uid="${uid:-8:8}"
 		case "${CONFIG_mysql_dump_compression}" in
 		'gzip')
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" | gzip_compression > "$cfname";
+		  $MYSQLDUMP "${opt[@]}" "$@" | gzip_compression > "$cfname";
 		  ;;
 		'bzip2')
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" | bzip2_compression > "$cfname";
+		  $MYSQLDUMP "${opt[@]}" "$@" | bzip2_compression > "$cfname";
 		  ;;
 		*)
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" > "$cfname";
+		  $MYSQLDUMP "${opt[@]}" "$@" > "$cfname";
 		  ;;
 		esac
 		add_manifest_entry "$manifest_file" "$cfname" "$pid" "$db" && parse_manifest "$manifest_file" && cp -al "$cfname" "${CONFIG_backup_dir}"/latest/ && echo "Generated master backup $cfname" && return 0 || return 1
@@ -734,29 +767,29 @@ process_dbs() {
 		case "${CONFIG_mysql_dump_compression}" in
 		'gzip')
 		  if (( $filename_flags & $filename_flag_gz )); then
-			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | gzip_compression > "$cfname";
+			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") | gzip_compression > "$cfname";
 		  elif (( $filename_flags & $filename_flag_bz2 )); then
-			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | gzip_compression > "$cfname";
+			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") | gzip_compression > "$cfname";
 		  else
-			diff "${manifest_latest_master_entry[0]}" <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | gzip_compression > "$cfname";
+			diff "${manifest_latest_master_entry[0]}" <($MYSQLDUMP "${opt[@]}" "$@") | gzip_compression > "$cfname";
 		  fi
 		  ;;
 		'bzip2')
 		  if (( $filename_flags & $filename_flag_gz )); then
-			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | bzip2_compression > "$cfname";
+			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") | bzip2_compression > "$cfname";
 		  elif (( $filename_flags & $filename_flag_bz2 )); then
-			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | bzip2_compression > "$cfname";
+			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") | bzip2_compression > "$cfname";
 		  else
-			diff "${manifest_latest_master_entry[0]}" <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") | bzip2_compression > "$cfname";
+			diff "${manifest_latest_master_entry[0]}" <($MYSQLDUMP "${opt[@]}" "$@") | bzip2_compression > "$cfname";
 		  fi
 		  ;;
 		*)
 		  if (( $filename_flags & $filename_flag_gz )); then
-			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") > "$cfname";
+			diff <(gzip_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") > "$cfname";
 		  elif (( $filename_flags & $filename_flag_bz2 )); then
-			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") > "$cfname";
+			diff <(bzip2_compression -dc "${manifest_latest_master_entry[0]}") <($MYSQLDUMP "${opt[@]}" "$@") > "$cfname";
 		  else
-			diff "${manifest_latest_master_entry[0]}" <(mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@") > "$cfname";
+			diff "${manifest_latest_master_entry[0]}" <($MYSQLDUMP "${opt[@]}" "$@") > "$cfname";
 		  fi
 		  ;;
 		esac
@@ -770,28 +803,28 @@ process_dbs() {
 	  if (( $CONFIG_dryrun )); then
 		case "${CONFIG_mysql_dump_compression}" in
 		'gzip')
-		  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt[@]} $@ | gzip_compression > ${cfname}"
+		  echo "dry-running: $MYSQLDUMP ${opt[@]} $@ | gzip_compression > ${cfname}"
 		  ;;
 		'bzip2')
-		  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt[@]} $@ | bzip2_compression > ${cfname}"
+		  echo "dry-running: $MYSQLDUMP ${opt[@]} $@ | bzip2_compression > ${cfname}"
 		  ;;
 		*)
-		  echo "dry-running: mysqldump --user=${CONFIG_mysql_dump_username} --password=${CONFIG_mysql_dump_password} --host=${CONFIG_mysql_dump_host} ${opt[@]} $@ > ${cfname}"
+		  echo "dry-running: $MYSQLDUMP ${opt[@]} $@ > ${cfname}"
 		  ;;
 		esac
 		return 0;
 	  else
 		case "${CONFIG_mysql_dump_compression}" in
 		'gzip')
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" | gzip_compression > "${cfname}"
+		  $MYSQLDUMP "${opt[@]}" "$@" | gzip_compression > "${cfname}"
 		  ret=$?
 		  ;;
 		'bzip2')
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" | bzip2_compression > "${cfname}"
+		  $MYSQLDUMP "${opt[@]}" "$@" | bzip2_compression > "${cfname}"
 		  ret=$?
 		  ;;
 		*)
-		  mysqldump --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${opt[@]}" "$@" > "${cfname}"
+		  $MYSQLDUMP "${opt[@]}" "$@" > "${cfname}"
 		  ret=$?
 		  ;;
 		esac
@@ -855,7 +888,6 @@ directory_checks_enable_logging () {
 	[[ "${CONFIG_mysql_dump_dbstatus}" = 'yes' ]] && { checkdirs=( "${checkdirs[@]}" "${CONFIG_backup_dir}/status" ); }
 
     tmp_permcheck=0
-    printf '# Checking for permissions to write to folders:\n'
 
 
     # "dirname ${CONFIG_backup_dir}" exists?
@@ -878,14 +910,9 @@ directory_checks_enable_logging () {
 
 
     # -> check base folder
-    printf 'base folder %s ... ' "$(dirname "${CONFIG_backup_dir}")"
     if [[ -d "$(dirname "${CONFIG_backup_dir}")" ]]; then
 
-	printf 'exists ... ok.\n'
-	printf 'backup folder %s ... ' "${CONFIG_backup_dir}"
-
 	if [[ -d "${CONFIG_backup_dir}" ]]; then
-	    printf 'exists ... writable? ' 
 	    if (( $CONFIG_dryrun )); then
 	      printf 'dry-running. Skipping. Logging to /tmp\n'
 	      log_file="/tmp/${CONFIG_mysql_dump_host}-`date +%N`.log"
@@ -894,7 +921,6 @@ directory_checks_enable_logging () {
 	      tmp_permcheck=1
 	    else
 		if chk_folder_writable "${CONFIG_backup_dir}"; then
-		  printf 'yes. Proceeding.\n'
 		  log_file="${CONFIG_backup_dir}/${CONFIG_mysql_dump_host}-`date +%N`.log"
 		  log_errfile="${CONFIG_backup_dir}/ERRORS_${CONFIG_mysql_dump_host}-`date +%N`.log"
 		  activateIO "$log_file" "$log_errfile"
@@ -1068,7 +1094,7 @@ parse_databases() {
   printf "# Parsing databases ... "
   # bash 3.0
   local i;i=0;
-  while read -r; do alldbnames[i++]="$REPLY"; done < <(mysql --user="${CONFIG_mysql_dump_username}" --password="${CONFIG_mysql_dump_password}" --host="${CONFIG_mysql_dump_host}" "${mysql_opt[@]}" --batch --skip-column-names -e "show databases")
+  while read -r; do alldbnames[i++]="$REPLY"; done < <($MYSQL "${mysql_opt[@]}" --batch --skip-column-names -e "show databases")
   unset i
 
   # mkfifo foo || exit; trap 'rm -f foo' EXIT
@@ -1648,8 +1674,11 @@ method_backup () {
 	load_default_config
 
 	trap mail_cleanup EXIT SIGHUP SIGINT SIGQUIT SIGTERM
-	if [[ -r "${CONFIG_configfile}" ]]; then source "${CONFIG_configfile}"; echo "Parsed config file \"${CONFIG_configfile}\""; else let "N |= $N_config_file_missing"; fi; echo
+	if [[ -r "${CONFIG_configfile}" ]]; then source "${CONFIG_configfile}"; else let "N |= $N_config_file_missing"; fi
 	if (( $opt_flag_config_file )); then if [[ -r "${opt_config_file}" ]]; then source "${opt_config_file}"; let "N |= $N_arg_conffile_parsed"; else let "N |= $N_arg_conffile_unreadable"; fi; else let "N |= $N_too_many_args"; fi
+
+	# load mysql commands
+	mysql_commands
 
 	(( $CONFIG_dryrun )) && {
 	  echo "NOTE: We are dry-running. That means, that the script just shows you what it would do, if it were operating normally."
@@ -1974,7 +2003,7 @@ method_backup () {
 	# -> finished information
 	echo "Total disk space used for backup storage..."
 	echo "Size - Location"
-	echo `du -hsH "${CONFIG_backup_dir}"`
+	echo `du -hs $OS_du_extra_option "${CONFIG_backup_dir}"`
 	echo
 	echo "======================================================================"
 	# <- finished information
@@ -2017,6 +2046,9 @@ method_list_manifest_entries () {
 
 	if [[ -r "${CONFIG_configfile}" ]]; then source "${CONFIG_configfile}"; echo "Parsed config file \"${CONFIG_configfile}\""; else let "N |= $N_config_file_missing"; fi; echo
 	if (( $opt_flag_config_file )); then if [[ -r "${opt_config_file}" ]]; then source "${opt_config_file}"; let "N |= $N_arg_conffile_parsed"; else let "N |= $N_arg_conffile_unreadable"; fi; else let "N |= $N_too_many_args"; fi
+
+	# load mysql commands
+	mysql_commands
 
 	export LC_ALL=C
 	PROGNAME=`basename $0`
@@ -2214,7 +2246,7 @@ NO_ARGS=0
 E_OPTERROR=85
 
 if (( $# == $NO_ARGS )); then   # Script invoked with no command-line args?
-  echo "Invoking backup method."; echo; method_backup
+  method_backup
 fi
 
 while getopts ":c:blh" Option

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -30,6 +30,10 @@
 # The path to file where "login path" is stored
 #CONFIG_mysql_dump_login_path_file=''
 
+# If connecting to a MariaDB server, use the following "extra file" instead of "login path"
+# Read more at https://mariadb.com/kb/en/mysql_config_editor-compatibility/
+#CONFIG_mysql_dump_config_extra_file='automysqldump'
+
 # Host name (or IP address) of MySQL server e.g localhost
 #CONFIG_mysql_dump_host='localhost'
 

--- a/automysqlbackup.conf
+++ b/automysqlbackup.conf
@@ -20,6 +20,16 @@
 # Password to access the MySQL server e.g. password
 #CONFIG_mysql_dump_password=''
 
+# If a "login path" should be used instead of username and password above to access the MySQL server
+# Read more at https://dev.mysql.com/doc/refman/5.6/en/option-file-options.html#option_general_login-path
+#CONFIG_mysql_dump_encrypted_login='no'
+
+# The "login path"
+#CONFIG_mysql_dump_login_path='automysqldump'
+
+# The path to file where "login path" is stored
+#CONFIG_mysql_dump_login_path_file=''
+
 # Host name (or IP address) of MySQL server e.g localhost
 #CONFIG_mysql_dump_host='localhost'
 
@@ -104,7 +114,7 @@
 #CONFIG_mysql_dump_commcomp='no'
 
 # Use ssl encryption with mysqldump?
-#CONFIG_mysql_dump_usessl='yes'
+#CONFIG_mysql_dump_usessl='no'
 
 # For connections to localhost. Sometimes the Unix socket file must be specified.
 #CONFIG_mysql_dump_socket=''


### PR DESCRIPTION
To avoid the "Using a password on the command line interface can be insecure" warning in MySQL, support for login path was added in [an other repository](https://github.com/arteria/automysqlbackup/commit/d94d1a26421335a0ef3d4cd9a73e308f6c72f340).

I recently changed to MariaDB on one server, which have no such solution and instead suggests using [extra configuration file](https://mariadb.com/kb/en/mysql_config_editor-compatibility/) with secure permissions.

Since this repo seemed to have "more" activity I thought it would be good to merge here.